### PR TITLE
fix: return cached result from `WasiHttpResponseWrapper.stream`

### DIFF
--- a/src/urllib3/contrib/wasi/response.py
+++ b/src/urllib3/contrib/wasi/response.py
@@ -103,12 +103,15 @@ class WasiHttpResponseWrapper(BaseHTTPResponse):
     def stream(
         self, amt: int | None = 2**16, decode_content: bool | None = None
     ) -> typing.Iterator[bytes]:
-        while True:
-            data = self.read(amt=amt, decode_content=decode_content)
-            if len(data) != 0:
-                yield data
-            else:
-                break
+        if self._body:
+            yield self._body
+        else:
+            while True:
+                data = self.read(amt=amt, decode_content=decode_content)
+                if len(data) != 0:
+                    yield data
+                else:
+                    break
 
     def read(
         self,


### PR DESCRIPTION
`requests` will call `stream` and expects data to be present there, so we need to return the cached result. Otherwise `requests` will only try to poll the exhausted stream and will not get any data, resulting in an empty body.

Found while testing https://github.com/urllib3/urllib3/pull/3593 with `requests`.