### PR TITLE
fix: correctly stream large responses under WASI

### DIFF
--- a/src/urllib3/contrib/wasi/connection.py
+++ b/src/urllib3/contrib/wasi/connection.py
@@ -127,6 +127,8 @@ class WasiHTTPConnection:
         if self._response is not None:
             return WasiHttpResponseWrapper(
                 internal_response=self._response,
+                preload_content=self._response.request.preload_content,
+                decode_content=self._response.request.decode_content,
                 connection=self,
             )
         else:


### PR DESCRIPTION
Given the following code and a rather large response (>=10k), the code prior to this change would only buffer up the first chunk/part of the response. This happens due to a disagreement about `preload_content` between `urllib3.contrib.wasi.wasi.convert_body` and `urllib3.contrib.wasi.response.WasiHttpResponseWrapper`.

```python
import urllib3

def perform_request(url: str) -> str:
    resp = urllib3.request(
        "GET",
        url,
        preload_content=False,
        decode_content=False,
    )

    data = b""
    for part in resp.stream():
        data += part
    return data.decode("utf-8")
```

This may affect all users but especially `requests`, which uses `preload_content=False` and `decode_content=False`.