### PR TITLE
fix: `ACCEPT_ENCODING` & `make_headers` if `zlib` is missing

### DIFF
--- a/src/urllib3/util/request.py
+++ b/src/urllib3/util/request.py
@@ -18,7 +18,15 @@ if typing.TYPE_CHECKING:
 SKIP_HEADER = "@@@SKIP_HEADER@@@"
 SKIPPABLE_HEADERS = frozenset(["accept-encoding", "host", "user-agent"])
 
-ACCEPT_ENCODING = "gzip,deflate"
+ACCEPT_ENCODING = "*;q=0"
+
+try:
+    import zlib as _unused_module_zlib  # type: ignore[import-not-found] # noqa: F401
+except ImportError:
+    pass
+else:
+    ACCEPT_ENCODING = "gzip,deflate"
+
 try:
     try:
         import brotlicffi as _unused_module_brotli  # type: ignore[import-not-found] # noqa: F401
@@ -76,12 +84,12 @@ def make_headers(
 
     :param accept_encoding:
         Can be a boolean, list, or string.
-        ``True`` translates to 'gzip,deflate'.  If the dependencies for
-        Brotli (either the ``brotli`` or ``brotlicffi`` package) and/or Zstandard
-        (the ``zstandard`` package) algorithms are installed, then their encodings are
-        included in the string ('br' and 'zstd', respectively).
-        List will get joined by comma.
-        String will be used as provided.
+        ``True`` translates to '\\*;q=0'.  If the dependencies for Gzip/Deflate
+        (the ``zlib`` package), Brotli (either the ``brotli`` or ``brotlicffi``
+        package), and/or Zstandard (the ``zstandard`` package) algorithms are
+        installed, then their encodings are included in the string ('gzip',
+        'deflate', 'br', and 'zstd', respectively). List will get joined by
+        comma. String will be used as provided.
 
     :param user_agent:
         String representing the user-agent you want, such as


### PR DESCRIPTION
CPython can be compiled without zlib, e.g. for WASI targets. This was already considered for the decompression routines in `urllib3.response`, but the `Accept-Encoding` header in `urllib3.util.request` always added `gzip` & `deflate` to the set of accepted encodings. Esp. in combination with `requests`, that had the unexpected outcome that `requests.get(...).text` returned the compressed server response instead of usable decompressed content.
